### PR TITLE
Fix Exit Codes in charge and discharge Functions

### DIFF
--- a/battery.sh
+++ b/battery.sh
@@ -741,7 +741,7 @@ if [[ "$action" == "charge" ]]; then
 	change_magsafe_led_color "green" # LED orange for not charging
 	log "Charging completed at $battery_percentage%"
 
-	exit 2
+	exit 0
 
 fi
 
@@ -791,7 +791,7 @@ if [[ "$action" == "discharge" ]]; then
 	
 	log "Discharging completed at $battery_percentage%"
 
-	exit 2
+	exit 0
 
 fi
 


### PR DESCRIPTION
#2 The issue occurs at line 1266 in the following code:

https://github.com/js4jiang5/BatteryOptimizer_for_MAC/blob/d2cf60bfcc6265f2c960cc54d61f3356a0e49be2/battery.sh#L1266

The exit code was incorrect. After reviewing the code, I corrected the exit code in the `charge` and `discharge` functions to return `0` when there are no errors, ensuring that the script behaves as expected in normal conditions. 