### PR TITLE
Add improved error handling with command suggestions

### DIFF
--- a/battery.sh
+++ b/battery.sh
@@ -182,9 +182,46 @@ else
 	fi
 fi
 
+# Validate action
+if ! valid_action "$action"; then
+    exit 1
+fi
+
 ## ###############
 ## Helpers
 ## ###############
+
+
+valid_action() {
+    local action=$1
+    
+	# List of valid actions
+	VALID_ACTIONS=("help" "maintain" "calibrate" "schedule" "charge" "discharge" "status" "dailylog" "logs" "language" "update" "version" "reinstall" "uninstall") 
+    
+    # Check if action is valid
+    local action_valid=false
+    for valid_action in "${VALID_ACTIONS[@]}"; do
+        if [[ "$action" == "$valid_action" ]]; then
+            action_valid=true
+            break
+        fi
+    done
+    
+    if ! $action_valid; then
+        echo "Error: Unknown command '$action'"
+        # Find similar commands
+        echo "Did you mean one of these?"
+        for valid_action in "${VALID_ACTIONS[@]}"; do
+            if [[ "$valid_action" == *"${action:0:3}"* ]]; then
+                echo "  - $valid_action"
+            fi
+        done
+        echo "Run 'battery' without parameters, for list of valid commands."
+        return 1
+    fi
+    
+    return 0
+}
 
 function ha_webhook() {
 	DST=http://homeassistant.local:8123

--- a/battery.sh
+++ b/battery.sh
@@ -182,11 +182,6 @@ else
 	fi
 fi
 
-# Validate action
-if ! valid_action "$action"; then
-    exit 1
-fi
-
 ## ###############
 ## Helpers
 ## ###############
@@ -196,7 +191,7 @@ function valid_action() {
     local action=$1
     
     # List of valid actions
-    VALID_ACTIONS=("help" "maintain" "calibrate" "schedule" "charge" "discharge" "status" "dailylog" "logs" "language" "update" "version" "reinstall" "uninstall") 
+    VALID_ACTIONS=("" "maintain" "calibrate" "schedule" "charge" "discharge" "status" "dailylog" "logs" "language" "update" "version" "reinstall" "uninstall") 
     
     # Check if action is valid
     local action_valid=false
@@ -866,6 +861,11 @@ function maintain_is_running() {
 if [ -z "$action" ] || [[ "$action" == "help" ]]; then
 	echo -e "$helpmessage"
 	exit 0
+fi
+
+# Validate action
+if ! valid_action "$action"; then
+    exit 1
 fi
 
 # Visudo message

--- a/battery.sh
+++ b/battery.sh
@@ -192,11 +192,11 @@ fi
 ## ###############
 
 
-valid_action() {
+function valid_action() {
     local action=$1
     
-	# List of valid actions
-	VALID_ACTIONS=("help" "maintain" "calibrate" "schedule" "charge" "discharge" "status" "dailylog" "logs" "language" "update" "version" "reinstall" "uninstall") 
+    # List of valid actions
+    VALID_ACTIONS=("help" "maintain" "calibrate" "schedule" "charge" "discharge" "status" "dailylog" "logs" "language" "update" "version" "reinstall" "uninstall") 
     
     # Check if action is valid
     local action_valid=false


### PR DESCRIPTION
Improve user experience by adding proper error handling for invalid commands. Previously, when users entered an invalid command (e.g., `battery calibrates`, `battery schedules`), the tool would silently exit without any feedback.

Changes made:
- Add `valid_action()` function to validate user commands
- Show the error messages for invalid or missing commands
- Provide suggestions for mistyped commands