### PR TITLE
Fix race condition in maintain loop during suspend

### DIFF
--- a/battery.sh
+++ b/battery.sh
@@ -1784,13 +1784,13 @@ if [[ "$action" == "maintain_synchronous" ]]; then
 
 			# Keep track of SMC charging status
 			smc_charging_status=$(get_smc_charging_status)
-			if [[ "$battery_percentage" -ge "$setting" ]] && [[ "$smc_charging_status" == "enabled" ]]; then
+			if [[ "$battery_percentage" -ge "$setting" ]] && [[ "$smc_charging_status" == "enabled" ]] && [[ "$maintain_status" == "active" ]]; then
 
 				log "Stop charge above $setting"
 				disable_charging
 				sleep_duration=60
 
-			elif [[ "$battery_percentage" -lt "$lower_limit" ]] && [[ "$smc_charging_status" == "disabled" ]]; then
+			elif [[ "$battery_percentage" -lt "$lower_limit" ]] && [[ "$smc_charging_status" == "disabled" ]] && [[ "$maintain_status" == "active" ]]; then
 
 				log "Charge below $lower_limit"
 				enable_charging


### PR DESCRIPTION
## Problem

When `battery maintain suspend` is called, the signal handler (`ack_SIG`) sets `maintain_status` to "suspended" and calls `enable_charging()`. However, if the signal arrives while the maintain loop is in the middle of the "active" block, the loop continues executing after the signal handler returns and can immediately call `disable_charging()` — undoing the suspend.

This causes `battery maintain suspend` to sometimes fail to enable charging, depending on timing.

## Fix

Added `&& [[ "$maintain_status" == "active" ]]` to the charging control conditions in the maintain loop. This ensures the loop won't change charging state after the status has been set to "suspended".

## Testing

Tested by running `battery maintain 80`, waiting for the loop to be active, then calling `battery maintain suspend`. Verified that charging remains enabled and battery charges past the maintain threshold.