### PR TITLE
fix: prevent privilege escalation with root-owned dedicated directory

### DIFF
--- a/battery.sh
+++ b/battery.sh
@@ -5,15 +5,15 @@
 ## variables are used by this binary as well at the update script
 ## ###############
 BATTERY_CLI_VERSION="v2.0.28"
-BATTERY_VISUDO_VERSION="v1.0.4"
+BATTERY_VISUDO_VERSION="v1.0.5"
 
 # Path fixes for unexpected environments
-PATH=/opt/homebrew/bin:/opt/homebrew/sbin:/usr/local/bin:/usr/bin:/bin:/usr/sbin:/sbin
+PATH=/usr/local/co.battery-optimizer:/opt/homebrew/bin:/opt/homebrew/sbin:/usr/local/bin:/usr/bin:/bin:/usr/sbin:/sbin
 
 ## ###############
 ## Variables
 ## ###############
-binfolder=/usr/local/bin
+binfolder=/usr/local/co.battery-optimizer
 visudo_folder=/private/etc/sudoers.d
 visudo_file=${visudo_folder}/battery
 configfolder=$HOME/.battery
@@ -1225,14 +1225,14 @@ if [[ "$action" == "visudo" ]]; then
 		setting=$USER
 	fi
 
-	# Set visudo tempfile ownership to current user
+	# Create secure temp directory for visudo file
 	log "Setting visudo file permissions to $setting"
-	sudo chown -R $setting $configfolder
+	visudo_tmpdir=$(mktemp -d "${TMPDIR:-/tmp}/battery-visudo.XXXXXX")
+	trap 'rm -rf "$visudo_tmpdir"' EXIT
 
 	# Write the visudo file to a tempfile
-	visudo_tmpfile="$configfolder/visudo.tmp"
-	sudo rm $visudo_tmpfile 2>/dev/null
-	echo -e "$visudoconfig" >$visudo_tmpfile
+	visudo_tmpfile="$visudo_tmpdir/visudo.tmp"
+	echo -e "$visudoconfig" >"$visudo_tmpfile"
 
 	# If the visudo file is the same (no error, exit code 0), set the permissions just
 	if sudo cmp $visudo_file $visudo_tmpfile &>/dev/null; then


### PR DESCRIPTION
## Motivation

This PR addresses the security vulnerability reported in #69. The setup script was installing `smc` and `battery` with user ownership in `/usr/local/bin`, which allows any process running as the installing user to replace these executables with arbitrary code. Since `smc` is executed via sudo (configured in `/etc/sudoers.d`), this creates a local privilege escalation vulnerability where malicious code can gain root access.

Additionally, even with root-owned executables, user-writable parent directories allow attackers to remove and replace files. This is addressed by using a dedicated root-owned directory.

## Summary

- Created dedicated directory `/usr/local/co.battery-optimizer` with root ownership
- All executables (`smc`, `battery`, `shutdown.sh`) are now root-owned
- Created symlinks in `/usr/local/bin` for PATH accessibility (symlinks also root-owned)
- Added cleanup step to remove old installations from `/usr/local/bin`
- Bumped `BATTERY_VISUDO_VERSION` to `v1.0.5` (paths changed in sudoers config)
- Added security documentation comment explaining the threat model
- Removed redundant `chmod +x` calls since mode 755 already includes execute permission

Migration handling in `update.sh`:
- Cleanup old files from `/usr/local/bin` (preserves existing symlinks to new location)
- Ensure binfolder exists with correct root ownership using `install -d`
- Create/update symlinks for PATH accessibility
- `shutdown.sh` symlink only created when the file is actually installed (avoids broken symlinks)

## References

- Fixes #69
- Based on the fix implemented in upstream: https://github.com/actuallymentor/battery/issues/443