### PR TITLE
eat(cli): 重構 battery CLI 國際化體系並新增簡體中文支援

### DIFF
--- a/i18n/battery_i18n.sh
+++ b/i18n/battery_i18n.sh
@@ -1,0 +1,37 @@
+# Battery CLI i18n loader (compatibility entrypoint)
+# battery.sh sources this file; this loader then sources common helpers and all lang_*.sh catalogs.
+
+if [[ -n "${BATTERY_I18N_LOADER_LOADED:-}" ]]; then
+  return 0 2>/dev/null || exit 0
+fi
+BATTERY_I18N_LOADER_LOADED=1
+
+battery_i18n_loader_dir="$(cd "$(dirname "${BASH_SOURCE[0]:-$0}")" 2>/dev/null && pwd)"
+if [[ -z "$battery_i18n_loader_dir" ]]; then
+  echo "Error: unable to resolve battery i18n loader directory" >&2
+  return 1 2>/dev/null || exit 1
+fi
+
+if [[ ! -f "$battery_i18n_loader_dir/common.sh" ]]; then
+  echo "Error: missing i18n component: common.sh" >&2
+  return 1 2>/dev/null || exit 1
+fi
+# shellcheck disable=SC1090
+source "$battery_i18n_loader_dir/common.sh"
+
+battery_i18n_lang_found=false
+for battery_i18n_part in "$battery_i18n_loader_dir"/lang_*.sh; do
+  [[ -f "$battery_i18n_part" ]] || continue
+  # shellcheck disable=SC1090
+  source "$battery_i18n_part"
+  battery_i18n_lang_found=true
+done
+
+if ! $battery_i18n_lang_found; then
+  echo "Error: no i18n language catalogs found in $battery_i18n_loader_dir" >&2
+  return 1 2>/dev/null || exit 1
+fi
+
+unset battery_i18n_part
+unset battery_i18n_lang_found
+unset battery_i18n_loader_dir

--- a/i18n/common.sh
+++ b/i18n/common.sh
@@ -1,0 +1,202 @@
+# Battery CLI i18n common helpers and dispatchers
+# Sourced by i18n/battery_i18n.sh. Language catalogs live in lang_*.sh.
+
+if [[ -n "${BATTERY_I18N_COMMON_LOADED:-}" ]]; then
+  return 0 2>/dev/null || exit 0
+fi
+BATTERY_I18N_COMMON_LOADED=1
+
+function normalize_language_code() {
+	local raw="$1"
+	raw=$(echo "$raw" | tr '[:upper:]' '[:lower:]' | tr '-' '_')
+	case "$raw" in
+		cn|zh_cn|zh_cn*|zh_sg|zh_sg*|zh_my|zh_my*|zh_hans|zh_hans*)
+			echo "cn"
+			;;
+		tw|zh_tw|zh_tw*|zh_hk|zh_hk*|zh_mo|zh_mo*|zh_hant|zh_hant*)
+			echo "tw"
+			;;
+		us|en|en_us|en_us*|en_gb|en_gb*)
+			echo "us"
+			;;
+		"")
+			echo
+			;;
+		*)
+			echo
+			;;
+	esac
+}
+
+function resolve_cli_language() {
+	local configured_language
+	local system_locale
+	configured_language=$(normalize_language_code "$(read_config language)")
+	if [[ -n "$configured_language" ]]; then
+		CLI_LANG="$configured_language"
+	else
+		system_locale=$(defaults read -g AppleLocale 2>/dev/null)
+		CLI_LANG=$(normalize_language_code "$system_locale")
+		[[ -z "$CLI_LANG" ]] && CLI_LANG="us"
+	fi
+
+	if [[ "$CLI_LANG" == "tw" ]]; then
+		is_TW=true
+	else
+		is_TW=false
+	fi
+}
+
+
+function i18n_text_for_lang() {
+	local lang="$1"
+	local key="$2"
+	local fn="i18n_text_${lang}"
+	if declare -f "$fn" >/dev/null; then
+		"$fn" "$key"
+	else
+		return 1
+	fi
+}
+
+function i18n_help_message_for_lang() {
+	local lang="$1"
+	local fn="i18n_help_message_${lang}"
+	if declare -f "$fn" >/dev/null; then
+		"$fn"
+	else
+		return 1
+	fi
+}
+
+function i18n_schedule_display_text_for_lang() {
+	local lang="$1"
+	local schedule_txt="$2"
+	local fn="i18n_schedule_display_text_${lang}"
+	if declare -f "$fn" >/dev/null; then
+		"$fn" "$schedule_txt"
+	else
+		return 1
+	fi
+}
+
+function i18n_schedule_display_text() {
+	local schedule_txt="$1"
+	local lang="${CLI_LANG:-us}"
+	if i18n_schedule_display_text_for_lang "$lang" "$schedule_txt"; then
+		return 0
+	fi
+	if [[ "$lang" != "us" ]] && i18n_schedule_display_text_for_lang "us" "$schedule_txt"; then
+		return 0
+	fi
+	schedule_txt=${schedule_txt%" starting"*}
+	printf "%s\n" "$schedule_txt"
+}
+
+function i18n_text() {
+	local key="$1"
+	local lang="${CLI_LANG:-us}"
+	if i18n_text_for_lang "$lang" "$key"; then
+		return 0
+	fi
+	if [[ "$lang" != "us" ]] && i18n_text_for_lang "us" "$key"; then
+		return 0
+	fi
+	echo "$key"
+}
+
+function i18n_format() {
+	local key="$1"
+	shift
+	local format
+	format=$(i18n_text "$key")
+	printf "$format" "$@"
+}
+
+function i18n_log() {
+	local key="$1"
+	shift
+	log "$(i18n_format "$key" "$@")"
+}
+
+function i18n_logLF() {
+	local key="$1"
+	shift
+	logLF "$(i18n_format "$key" "$@")"
+}
+
+function i18n_logn() {
+	local key="$1"
+	shift
+	logn "$(i18n_format "$key" "$@")"
+}
+
+function i18n_echo() {
+	local key="$1"
+	shift
+	echo "$(i18n_format "$key" "$@")"
+}
+
+function lang_pick() {
+	local tw_text="$1"
+	local en_text="$2"
+	if [[ "${CLI_LANG:-us}" == "tw" ]]; then
+		printf "%s" "$tw_text"
+	else
+		printf "%s" "$en_text"
+	fi
+}
+
+function log_lang() {
+	local tw_text="$1"
+	local en_text="$2"
+	log "$(lang_pick "$tw_text" "$en_text")"
+}
+
+function logLF_lang() {
+	local tw_text="$1"
+	local en_text="$2"
+	logLF "$(lang_pick "$tw_text" "$en_text")"
+}
+
+function logn_lang() {
+	local tw_text="$1"
+	local en_text="$2"
+	logn "$(lang_pick "$tw_text" "$en_text")"
+}
+
+function echo_lang() {
+	local tw_text="$1"
+	local en_text="$2"
+	echo "$(lang_pick "$tw_text" "$en_text")"
+}
+
+function notify_msg() {
+	local title="$1"
+	local message="$2"
+	osascript -e 'display notification "'"$message"'" with title "'"$title"'" sound name "Blow"'
+}
+
+function notify_lang() {
+	local tw_message="$1"
+	local en_message="$2"
+	local tw_title="${3:-電池}"
+	local en_title="${4:-Battery}"
+	notify_msg "$(lang_pick "$tw_title" "$en_title")" "$(lang_pick "$tw_message" "$en_message")"
+}
+
+function i18n_notify() {
+	local title_key="$1"
+	local message_key="$2"
+	shift 2
+	notify_msg "$(i18n_text "$title_key")" "$(i18n_format "$message_key" "$@")"
+}
+
+function show_help() {
+	echo -e "$(i18n_format help_current_language)"
+	echo -e "$(i18n_format help_i18n_note)"
+	echo
+	if ! i18n_help_message_for_lang "${CLI_LANG:-us}"; then
+		i18n_help_message_for_lang "us" || true
+	fi
+}

--- a/i18n/lang_cn.sh
+++ b/i18n/lang_cn.sh
@@ -1,0 +1,303 @@
+# Battery CLI i18n Simplified Chinese catalog
+
+if [[ -n "${BATTERY_I18N_LANG_CN_LOADED:-}" ]]; then
+  return 0 2>/dev/null || exit 0
+fi
+BATTERY_I18N_LANG_CN_LOADED=1
+
+helpmessage_cn="
+
+Battery CLI 工具 $BATTERY_CLI_VERSION
+
+用法:
+
+  battery maintain PERCENTAGE[10-100,stop,suspend,recover] SAILING_TARGET[5-99]
+  - PERCENTAGE 为停止充电的上限电量百分比
+  - SAILING_TARGET 为重新开始充电的下限电量百分比；未指定时，默认为 PERCENTAGE-5
+    示例:
+    battery maintain 80 50    # 维持在 80%，滑行至 50%
+    battery maintain 80    # 等同于 battery maintain 80 75
+    battery maintain stop   # 停止维持程序、停用 daemon 并恢复充电；重启后不会自动执行
+    battery maintain suspend   # 暂停维持程序并恢复充电；重新接通电源后会自动恢复维持（例如旅行前暂时充到 100%）
+    battery maintain recover   # 恢复电池维持程序
+
+  battery calibrate
+    将电池放电至 15%，再充电至 100%，维持 1 小时后，再放电回维持电量，完成校准
+    如果笔记本上盖未开启或未接上电源，会先发送提醒通知
+    当上盖开启且已接上电源后，会自动开始校准
+    校准期间每个步骤完成或发生错误都会发送通知
+    如果希望通知会停留直到手动关闭，请设置：
+        settings > notifications > applications > Script Editor > Choose \"Alerts\"
+    如果使用外接屏幕，请设置：
+        system settings > notifications > check 'Allow notifications when mirroring or sharing the display'
+    eg: battery calibrate   # 开始校准
+    eg: battery calibrate stop # 停止校准并恢复 maintain
+
+  battery schedule
+    设置定期校准日程：每月最多 4 个日期、或每 1~12 周指定星期、或每 1~3 个月指定单一日期；默认为每月 1 号 9:00
+    示例:
+    battery schedule    # 每月 1 号 9:00 校准
+    battery schedule day 1 8 15 22    # 每月 1、8、15、22 号 9:00 校准
+    battery schedule day 3 18 hour 13    # 每月 3、18 号 13:00 校准
+    battery schedule day 6 16 26 hour 18 minute 30    # 每月 6、16、26 号 18:30 校准
+    battery schedule weekday 0 week_period 2 hour 21 minute 30 # 每 2 周的星期日 21:30 校准
+    battery schedule day 5 month_period 3 hour 21 minute 30 # 每 3 个月的 5 号 21:00 校准
+    battery schedule disable    # 禁用定期校准
+    battery schedule enable    # 启用定期校准
+    限制:
+        1. 每月最多 4 个日期
+        2. day 范围 [1-28]
+        3. hour 范围 [0-23]
+        4. minute 范围 [0-59]
+        5. weekday 范围 [0-6] 0:Sunday, 1:Monday, ...
+        6. week_period 范围 [1-12]
+        7. month_period 范围 [1-3]
+
+  battery charge LEVEL[1-100, stop]
+    将电池充到指定百分比，达到后停止充电
+    eg: battery charge 90
+    eg: battery charge stop # 停止正在运行的 charge 进程并停止充电
+
+  battery discharge LEVEL[1-100, stop]
+    阻止电源输入，直到电池下降到指定百分比
+    eg: battery discharge 90
+    eg: battery discharge stop # 停止正在运行的 discharge 进程并停止放电
+
+  battery status
+    显示电池 SMC 状态、容量、温度、健康度与循环次数
+
+  battery dailylog
+    显示每日日志与日志存放位置
+
+  battery changelog
+    显示 GitHub 最新版本更新内容
+
+  battery calibratelog
+    显示校准历史
+
+  battery logs LINES[integer, optional]
+    显示 Battery CLI 与 GUI 日志
+    eg: battery logs 100
+
+  battery language LANG[tw,cn,us,en,zh-TW,zh-CN,zh-Hant,zh-Hans,list]
+    eg: battery language cn     # 以简体中文显示状态与通知（若支持）
+    eg: battery language zh-CN  # cn 的别名
+    eg: battery language tw     # 以繁体中文显示状态与通知（若支持）
+    eg: battery language zh-TW  # tw 的别名
+    eg: battery language en     # us 的别名（英文）
+    eg: battery language us     # 以英文显示状态与通知
+    eg: battery language list   # 显示支持语言与别名
+
+  battery ssd
+    显示 SSD disk0 状态
+
+  battery ssdlog
+    显示 SSD disk0 每日日志
+
+  battery update
+    将 battery 工具更新到最新版本
+
+  battery version
+    显示当前版本
+
+  battery reinstall
+    重新安装最新版 battery 工具（重新执行安装脚本）
+
+  battery uninstall
+    恢复充电，并移除 smc 工具与 battery 脚本
+"
+
+
+
+function i18n_help_message_cn() {
+	printf "%s\n" "$helpmessage_cn"
+}
+
+function i18n_schedule_display_text_cn() {
+	local schedule_txt="$1"
+	if ! [[ $schedule_txt =~ "week" ]]; then
+		if ! [[ $schedule_txt =~ "month" ]]; then
+			schedule_txt=${schedule_txt/"Schedule calibration on day"/"电池自动校准日程安排在"}
+			schedule_txt=${schedule_txt/"at"/"日"}
+		else
+			schedule_txt=${schedule_txt/"Schedule calibration on day"/"电池自动校准日程安排在"}
+			schedule_txt=${schedule_txt/"every "/"日每"}
+			schedule_txt=${schedule_txt/"month at"/"个月"}
+			schedule_txt=${schedule_txt%" starting"*}
+		fi
+	else
+		schedule_txt=${schedule_txt/"Schedule calibration on"/"电池自动校准日程安排在"}
+		schedule_txt=${schedule_txt/"SUN"/"星期日"}
+		schedule_txt=${schedule_txt/"MON"/"星期一"}
+		schedule_txt=${schedule_txt/"TUE"/"星期二"}
+		schedule_txt=${schedule_txt/"WED"/"星期三"}
+		schedule_txt=${schedule_txt/"THU"/"星期四"}
+		schedule_txt=${schedule_txt/"FRI"/"星期五"}
+		schedule_txt=${schedule_txt/"SAT"/"星期六"}
+		schedule_txt=${schedule_txt/"every "/"每"}
+		schedule_txt=${schedule_txt/"week at"/"周"}
+		schedule_txt=${schedule_txt%" starting"*}
+	fi
+	printf "%s\n" "$schedule_txt 开始"
+}
+
+function i18n_text_cn() {
+	local key="$1"
+	case "$key" in
+		invalid_action) echo "错误：未知命令 '%s'" ;;
+		did_you_mean) echo "你是不是想用以下指令？" ;;
+		run_battery_help) echo "执行 'battery'（不带参数）以查看可用命令列表。" ;;
+		help_current_language) echo "当前语言：简体中文 (cn)" ;;
+		help_i18n_note) echo "提示：CLI 说明、状态、通知与主要命令输出均已支持国际化；少量复杂对话框仍沿用既有中英分支逻辑。" ;;
+		logs_cli_heading) echo "👾 Battery CLI 日志：" ;;
+		logs_gui_heading) echo "🖥️ Battery GUI 日志：" ;;
+		logs_config_heading) echo "📁 设置文件夹内容：" ;;
+		logs_data_heading) echo "⚙️ Battery 状态数据：" ;;
+		dailylog_heading) echo "每日日志 (%s)" ;;
+		ssdlog_heading) echo "SSD 每日日志 (%s)" ;;
+		calibratelog_heading) echo "校准日志 (%s)" ;;
+		language_list_header) echo "支持的语言（可用别名）：" ;;
+		language_list_tw) echo "  - tw / zh-TW / zh_TW / zh-Hant -> 繁体中文" ;;
+		language_list_cn) echo "  - cn / zh-CN / zh_CN / zh-Hans -> 简体中文" ;;
+		language_list_us) echo "  - us / en / en-US -> English" ;;
+		language_current_tw) echo "当前设置语言：繁体中文 (tw)" ;;
+		language_current_cn) echo "当前设置语言：简体中文 (cn)" ;;
+		language_current_us) echo "当前设置语言：英文 (us)" ;;
+		language_changed_tw) echo "显示语言改为繁体中文" ;;
+		language_changed_cn) echo "显示语言改为简体中文" ;;
+		language_changed_us) echo "显示语言改为英文" ;;
+		language_invalid) echo "指定语言无效。仅支持 [tw, cn, us]（也接受 en、zh-TW、zh-CN 等别名）" ;;
+		charge_invalid_setting) echo "错误：%s 不是有效的 battery charge 设置。请使用 0 到 100 的数字" ;;
+		charge_start) echo "开始充电至 %s%%（目前 %s%%）" ;;
+		charge_progress) echo "电池目前 %s%%（目标 %s%%）" ;;
+		charge_completed) echo "电池已充电至 %s%%" ;;
+		charge_abnormal) echo "错误：电池充电异常" ;;
+		discharge_invalid_setting) echo "错误：%s 不是有效的 battery discharge 设置。请使用 0 到 100 的数字" ;;
+		discharge_lid_open_required) echo "错误：放电前必须先打开笔记本上盖" ;;
+		discharge_start) echo "开始放电至 %s%%（目前 %s%%）" ;;
+		discharge_progress) echo "电池目前 %s%%（目标 %s%%）" ;;
+		discharge_completed) echo "电池已放电至 %s%%" ;;
+		discharge_abnormal) echo "错误：电池放电异常" ;;
+		maintain_recovering_percentage) echo "恢复电池优化设置 %s" ;;
+		maintain_no_setting_to_recover) echo "没有可恢复的设置，结束" ;;
+		maintain_invalid_setting) echo "错误：%s 不是有效的 battery maintain 设置。请使用 0 到 100 的数字" ;;
+		maintain_invalid_setting_with_keywords) echo "错误：%s 不是有效的 battery maintain 设置。请使用 0 到 100 的数字，或 'stop' / 'recover' 等动作关键字。" ;;
+		maintain_invalid_sailing_target) echo "错误：滑行目标 %s 不可大于或等于维持上限 %s" ;;
+		maintain_start) echo "开始电池优化：维持 %s%%，滑行至 %s%% %s" ;;
+		maintain_lid_open_required) echo "错误：放电前必须先打开笔记本上盖" ;;
+		maintain_trigger_force_discharge) echo "启用充电限制前，先放电至 %s%%" ;;
+		maintain_force_discharge_done) echo "预先放电完成，继续进入维持循环" ;;
+		maintain_force_discharge_skipped) echo "未要求预先放电，跳过" ;;
+		maintain_charging_and_maintaining) echo "开始充电并维持在 %s%%（目前 %s%%）" ;;
+		maintain_recover_wait) echo "5 秒内恢复，请稍等 ." ;;
+		maintain_suspend_wait) echo "5 秒内暂停，请稍等 ." ;;
+		maintain_recovered) echo "电池优化已恢复" ;;
+		maintain_recovered_ac_reconnected) echo "重新接通电源，电池优化已恢复" ;;
+		maintain_recover_failed) echo "错误：电池优化恢复失败" ;;
+		maintain_already_running) echo "电池优化已在执行中" ;;
+		maintain_not_running) echo "电池优化未在执行" ;;
+		maintain_suspended) echo "电池优化已暂停" ;;
+		maintain_suspend_failed) echo "错误：电池优化暂停失败" ;;
+		maintain_calibration_process_stopped) echo "🚨 已停止校准程序" ;;
+		maintain_start_discharge_now) echo "开始放电至 %s%%" ;;
+		status_battery_no_charging) echo "电池目前 %s%%, %sV, %s°C, 暂停充电" ;;
+		status_battery_charging) echo "电池目前 %s%%, %sV, %s°C, 充电中" ;;
+		status_battery_discharging) echo "电池目前 %s%%, %sV, %s°C, 放电中" ;;
+		status_health_cycle) echo "电池健康度 %s%%, 循环次数 %s" ;;
+		status_maintain_level_sailing) echo "%s%% 滑行至 %s%%" ;;
+		status_maintain_active) echo "你的电池当前维持在 %s" ;;
+		status_maintain_suspended_calibrating) echo "校准进行中，电池优化已暂停" ;;
+		status_maintain_suspended) echo "电池优化已暂停" ;;
+		status_maintain_not_running) echo "电池优化已经停止运行" ;;
+		title_battery) echo "电池" ;;
+		title_battery_optimizer) echo "BatteryOptimizer" ;;
+		title_battery_optimizer_mac) echo "BatteryOptimizer for MAC" ;;
+		title_calibration) echo "电池校准" ;;
+		title_calibration_error) echo "电池校准错误" ;;
+		dialog_button_ok) echo "OK" ;;
+		dialog_button_continue) echo "继续" ;;
+		dialog_button_yes) echo "Yes" ;;
+		dialog_button_no) echo "No" ;;
+		dialog_button_update_now) echo "立即更新" ;;
+		dialog_button_skip_version) echo "跳过此版本" ;;
+		press_any_key_continue) echo "按任意键继续" ;;
+		reinstall_preview) echo "这将执行 curl -sS %s/setup.sh | bash" ;;
+		uninstall_preview) echo "这会恢复充电，并移除 smc 工具与 battery 脚本" ;;
+		visudo_set_owner) echo "设置 visudo 文件权限给 %s" ;;
+		visudo_already_current) echo "当前 battery visudo 文件已符合版本 %s 的要求" ;;
+		visudo_updated_success) echo "Visudo 文件更新成功" ;;
+		visudo_validate_error) echo "验证 visudo 文件时发生错误（理论上不应发生）：" ;;
+		update_specified_file_missing) echo "错误：指定的更新文件不存在" ;;
+		update_dialog_latest) echo "%s 已是最新版，不需要更新" ;;
+		update_dialog_changelog) echo "%s 更新内容如下\n\n%s" ;;
+		update_dialog_confirm) echo "你现在要更新到%s 吗?" ;;
+		daily_log_table_header) echo "时间 容量 电压 温度 健康度 循环次数" ;;
+		ssd_log_table_header) echo "日期 结果 读取量 写入量 已用度 电源循环 通电时数 非正常关机 温度 错误" ;;
+		calibrate_log_table_header) echo "时间 已完成 校准前健康度 校准后健康度 耗时/错误" ;;
+		notify_battery_monthly_summary) echo "电池目前 %s%%, %sV, %s°C\n健康度 %s%%, 循环次数 %s" ;;
+		notify_calibration_tomorrow) echo "提醒你，明天 (%s) 将进行电池校准" ;;
+		notify_calibration_today) echo "提醒你，今天 (%s) 将进行电池校准" ;;
+		notify_update_available) echo "发现新版本 %s，请在 Terminal 中输入 \n\\\"battery update\\\" 更新" ;;
+		aldente_conflict_detected) echo "检测到 AlDente 正在运行，将其关闭以避免冲突" ;;
+		maintain_stop_charge_above) echo "高于 %s%% 停止充电" ;;
+		maintain_start_charge_below) echo "低于 %s%% 开始充电" ;;
+		maintain_prompt_discharge_now) echo "你要现在就放电到 %s%% 吗?" ;;
+		schedule_disabled) echo "电池自动校准日程已暂停" ;;
+		schedule_not_set) echo "你还没有设置电池自动校准日程" ;;
+		schedule_disabled_enable_by) echo "你的电池自动校准日程已暂停，可执行以下命令恢复" ;;
+		schedule_next_date) echo "下次校准日期是 %s" ;;
+		schedule_invalid_weekday) echo "错误：weekday 必须在 [0..6]" ;;
+		schedule_invalid_month_period) echo "错误：month_period 必须在 [1..3]" ;;
+		schedule_invalid_week_period) echo "错误：week_period 必须在 [1..12]" ;;
+		schedule_invalid_hour) echo "错误：hour 必须在 [0..23]" ;;
+		schedule_invalid_minute) echo "错误：minute 必须在 [0..59]" ;;
+		schedule_invalid_day) echo "错误：day 必须在 [1..28]" ;;
+		calibrate_skip_run) echo "跳过本次校准" ;;
+		calibrate_stop_running) echo "停止正在运行的校准进程" ;;
+		calibrate_require_maintain_before) echo "校准前必须先执行 battery maintain" ;;
+		calibrate_error_require_maintain_before_log) echo "校准错误：校准前必须先执行 battery maintain" ;;
+		calibrate_wait_open_lid_ac_notify) echo "准备进行电池校准, 您打开笔记本上盖并接上电源后将立刻开始" ;;
+		calibrate_wait_open_lid_ac_log) echo "校准：请打开笔记本上盖并接上电源以开始校准" ;;
+		calibrate_lid_not_open) echo "笔记本上盖没打开" ;;
+		calibrate_error_lid_not_open_log) echo "校准错误：笔记本上盖没打开" ;;
+		calibrate_no_ac_power) echo "电源没接" ;;
+		calibrate_error_no_ac_power_log) echo "校准错误：未接上电源" ;;
+		calibrate_no_ac_power_logfile) echo "未接上电源" ;;
+		calibrate_start_discharge_15_notify) echo "校准开始! \n开始放电至15%%" ;;
+		calibrate_start_discharge_15_log) echo "校准：校准开始，开始放电至 15%%" ;;
+		calibrate_fail_discharge_15) echo "未成功放电至15%%" ;;
+		calibrate_error_discharge_15_log) echo "校准错误：未成功放电至15%%" ;;
+		calibrate_done_discharge_15_charge_100_notify) echo "已放电至15%% \n开始充电到100%%" ;;
+		calibrate_done_discharge_15_charge_100_log) echo "校准：已放电至 15%%，开始充电到 100%%" ;;
+		calibrate_fail_charge_100) echo "未成功充电至100%%" ;;
+		calibrate_error_charge_100_log) echo "校准错误：未成功充电至100%%" ;;
+		calibrate_done_charge_100_wait_1h_notify) echo "已充电至100%% \n等待一小时" ;;
+		calibrate_done_charge_100_wait_1h_log) echo "校准：已充电至 100%%，等待一小时" ;;
+		calibrate_done_wait_1h_log) echo "校准：电池已维持在 100%% 一小时" ;;
+		calibrate_start_discharge_target_log) echo "校准：开始放电至维持电量" ;;
+		calibrate_done_wait_1h_discharge_target_notify) echo "电池已维持在 100%% 一小时 \n开始放电至 %s%%" ;;
+		calibrate_fail_discharge_target) echo "未成功放电至 %s%%" ;;
+		calibrate_error_discharge_target_log) echo "校准错误：未成功放电至 %s%%" ;;
+		calibrate_start_charge_100_notify) echo "校准开始！ \n准备充电至 100%%" ;;
+		calibrate_start_charge_100_log) echo "校准：校准开始，开始充电至 100%%" ;;
+		calibrate_done_wait_1h_discharge_15_notify) echo "电池已维持在 100%% 一小时 \n开始放电至 15%%" ;;
+		calibrate_start_discharge_15_phase_log) echo "校准：开始放电至 15%%" ;;
+		calibrate_done_discharge_15_log) echo "校准：已放电至 15%%" ;;
+		calibrate_start_charge_target_log) echo "校准：开始充电至维持电量" ;;
+		calibrate_done_discharge_15_charge_target_notify) echo "已放电至 15%% \n开始充电至 %s%%" ;;
+		calibrate_fail_charge_target) echo "未成功充电至 %s%%" ;;
+		calibrate_error_charge_target_log) echo "校准错误：未成功充电至 %s%%" ;;
+		calibrate_health_snapshot_log) echo "电池健康度 %s%%, %sV, %s°C" ;;
+		duration_days_part) echo "%s 天 " ;;
+		duration_hours_part) echo "%s 小时" ;;
+		duration_minutes_part) echo "%s 分" ;;
+		duration_seconds_part) echo "%s 秒" ;;
+		calibrate_completed_notify) echo "校准完成, 共花 %s%s %s\n电池目前 %s%%, %sV, %s°C\n健康度 %s%%, 循环次数 %s" ;;
+		calibrate_completed_log) echo "校准完成, 共花 %s%s %s %s." ;;
+		calibrate_completed_battery_log) echo "电池目前 %s%%, %sV, %s°C" ;;
+		calibrate_completed_health_log) echo "健康度 %s%%, 循环次数 %s" ;;
+		ssd_firmware_not_supported) echo "你的 SMART 固件目前不支持。" ;;
+		ssd_tool_not_installed) echo "你的 Mac 尚未安装 SMART 监控工具，可执行 \\\"brew install smartmontools\\\" 安装。" ;;
+		*) return 1 ;;
+	esac
+}

--- a/i18n/lang_tw.sh
+++ b/i18n/lang_tw.sh
@@ -1,0 +1,303 @@
+# Battery CLI i18n Traditional Chinese catalog
+
+if [[ -n "${BATTERY_I18N_LANG_TW_LOADED:-}" ]]; then
+  return 0 2>/dev/null || exit 0
+fi
+BATTERY_I18N_LANG_TW_LOADED=1
+
+helpmessage_tw="
+
+Battery CLI 工具 $BATTERY_CLI_VERSION
+
+用法:
+
+  battery maintain PERCENTAGE[10-100,stop,suspend,recover] SAILING_TARGET[5-99]
+  - PERCENTAGE 為停止充電的上限電量百分比
+  - SAILING_TARGET 為重新開始充電的下限電量百分比；若未指定，預設為 PERCENTAGE-5
+    範例:
+    battery maintain 80 50    # 維持在 80%，滑行至 50%
+    battery maintain 80    # 等同於 battery maintain 80 75
+    battery maintain stop   # 停止維持程序、停用 daemon 並恢復充電；重開機後不會自動執行
+    battery maintain suspend   # 暫停維持程序並恢復充電；重新接上電源後會自動恢復維持（例如旅行前暫時充到 100%）
+    battery maintain recover   # 恢復電池維持程序
+
+  battery calibrate
+    將電池放電至 15%，再充電至 100%，維持 1 小時後，再放電回維持電量，完成校正
+    若筆電上蓋未開啟或未接上電源，會先發送提醒通知
+    當上蓋開啟且已接上電源後，會自動開始校正
+    校正期間每個步驟完成或發生錯誤都會發送通知
+    若希望通知會停留直到手動關閉，請設定：
+        settings > notifications > applications > Script Editor > Choose \"Alerts\"
+    若使用外接螢幕，請設定：
+        system settings > notifications > check 'Allow notifications when mirroring or sharing the display'
+    eg: battery calibrate   # 開始校正
+    eg: battery calibrate stop # 停止校正並恢復 maintain
+
+  battery schedule
+    設定定期校正時程：每月最多 4 個日期、或每 1~12 週指定星期、或每 1~3 個月指定單一日期；預設為每月 1 號 9:00
+    範例:
+    battery schedule    # 每月 1 號 9:00 校正
+    battery schedule day 1 8 15 22    # 每月 1、8、15、22 號 9:00 校正
+    battery schedule day 3 18 hour 13    # 每月 3、18 號 13:00 校正
+    battery schedule day 6 16 26 hour 18 minute 30    # 每月 6、16、26 號 18:30 校正
+    battery schedule weekday 0 week_period 2 hour 21 minute 30 # 每 2 週的星期日 21:30 校正
+    battery schedule day 5 month_period 3 hour 21 minute 30 # 每 3 個月的 5 號 21:00 校正
+    battery schedule disable    # 停用定期校正
+    battery schedule enable    # 啟用定期校正
+    限制:
+        1. 每月最多 4 個日期
+        2. day 範圍 [1-28]
+        3. hour 範圍 [0-23]
+        4. minute 範圍 [0-59]
+        5. weekday 範圍 [0-6] 0:Sunday, 1:Monday, ...
+        6. week_period 範圍 [1-12]
+        7. month_period 範圍 [1-3]
+
+  battery charge LEVEL[1-100, stop]
+    將電池充到指定百分比，達到後停止充電
+    eg: battery charge 90
+    eg: battery charge stop # 停止執行中的 charge 程序並停止充電
+
+  battery discharge LEVEL[1-100, stop]
+    阻止電源輸入，直到電池下降到指定百分比
+    eg: battery discharge 90
+    eg: battery discharge stop # 停止執行中的 discharge 程序並停止放電
+
+  battery status
+    顯示電池 SMC 狀態、容量、溫度、健康度與循環次數
+
+  battery dailylog
+    顯示每日日誌與日誌存放位置
+
+  battery changelog
+    顯示 Github 最新版本更新內容
+
+  battery calibratelog
+    顯示校正歷史
+
+  battery logs LINES[integer, optional]
+    顯示 Battery CLI 與 GUI 日誌
+    eg: battery logs 100
+
+  battery language LANG[tw,cn,us,en,zh-TW,zh-CN,zh-Hant,zh-Hans,list]
+    eg: battery language cn     # 以簡體中文顯示狀態與通知（若支援）
+    eg: battery language zh-CN  # cn 的別名
+    eg: battery language tw     # 以繁體中文顯示狀態與通知（若支援）
+    eg: battery language zh-TW  # tw 的別名
+    eg: battery language en     # us 的別名（英文）
+    eg: battery language us     # 以英文顯示狀態與通知
+    eg: battery language list   # 顯示支援語言與別名
+
+  battery ssd
+    顯示 SSD disk0 狀態
+
+  battery ssdlog
+    顯示 SSD disk0 每日日誌
+
+  battery update
+    將 battery 工具更新到最新版本
+
+  battery version
+    顯示目前版本
+
+  battery reinstall
+    重新安裝最新版 battery 工具（重新執行安裝腳本）
+
+  battery uninstall
+    恢復充電，並移除 smc 工具與 battery 腳本
+
+"
+
+
+function i18n_help_message_tw() {
+	printf "%s\n" "$helpmessage_tw"
+}
+
+function i18n_schedule_display_text_tw() {
+	local schedule_txt="$1"
+	if ! [[ $schedule_txt =~ "week" ]]; then
+		if ! [[ $schedule_txt =~ "month" ]]; then
+			schedule_txt=${schedule_txt/"Schedule calibration on day"/"電池自動校正時程安排在"}
+			schedule_txt=${schedule_txt/"at"/"日"}
+		else
+			schedule_txt=${schedule_txt/"Schedule calibration on day"/"電池自動校正時程安排在"}
+			schedule_txt=${schedule_txt/"every "/"日每"}
+			schedule_txt=${schedule_txt/"month at"/"個月"}
+			schedule_txt=${schedule_txt%" starting"*}
+		fi
+	else
+		schedule_txt=${schedule_txt/"Schedule calibration on"/"電池自動校正時程安排在"}
+		schedule_txt=${schedule_txt/"SUN"/"星期日"}
+		schedule_txt=${schedule_txt/"MON"/"星期一"}
+		schedule_txt=${schedule_txt/"TUE"/"星期二"}
+		schedule_txt=${schedule_txt/"WED"/"星期三"}
+		schedule_txt=${schedule_txt/"THU"/"星期四"}
+		schedule_txt=${schedule_txt/"FRI"/"星期五"}
+		schedule_txt=${schedule_txt/"SAT"/"星期六"}
+		schedule_txt=${schedule_txt/"every "/"每"}
+		schedule_txt=${schedule_txt/"week at"/"週"}
+		schedule_txt=${schedule_txt%" starting"*}
+	fi
+	printf "%s\n" "$schedule_txt 開始"
+}
+
+function i18n_text_tw() {
+	local key="$1"
+	case "$key" in
+		invalid_action) echo "錯誤：未知命令 '%s'" ;;
+		did_you_mean) echo "你是不是想用以下指令？" ;;
+		run_battery_help) echo "執行 'battery'（不帶參數）以查看可用指令清單。" ;;
+		help_current_language) echo "目前語言：繁體中文 (tw)" ;;
+		help_i18n_note) echo "提示：CLI 說明、狀態、通知與主要命令輸出皆已支援國際化；少量複雜對話框仍沿用既有中英分支邏輯。" ;;
+		logs_cli_heading) echo "👾 Battery CLI 日誌：" ;;
+		logs_gui_heading) echo "🖥️ Battery GUI 日誌：" ;;
+		logs_config_heading) echo "📁 設定資料夾內容：" ;;
+		logs_data_heading) echo "⚙️ Battery 狀態資料：" ;;
+		dailylog_heading) echo "每日日誌 (%s)" ;;
+		ssdlog_heading) echo "SSD 每日日誌 (%s)" ;;
+		calibratelog_heading) echo "校正日誌 (%s)" ;;
+		language_list_header) echo "支援語言（可用別名）：" ;;
+		language_list_tw) echo "  - tw / zh-TW / zh_TW / zh-Hant -> 繁體中文" ;;
+		language_list_cn) echo "  - cn / zh-CN / zh_CN / zh-Hans -> 簡體中文" ;;
+		language_list_us) echo "  - us / en / en-US -> English" ;;
+		language_current_tw) echo "目前設定語言：繁體中文 (tw)" ;;
+		language_current_cn) echo "目前設定語言：簡體中文 (cn)" ;;
+		language_current_us) echo "目前設定語言：英文 (us)" ;;
+		language_changed_tw) echo "顯示語言改為繁體中文" ;;
+		language_changed_cn) echo "顯示語言改為簡體中文" ;;
+		language_changed_us) echo "顯示語言改為英文" ;;
+		language_invalid) echo "指定語言無效。僅支援 [tw, cn, us]（也接受 en、zh-TW、zh-CN 等別名）" ;;
+		charge_invalid_setting) echo "錯誤：%s 不是有效的 battery charge 設定。請使用 0 到 100 的數字" ;;
+		charge_start) echo "開始充電至 %s%%（目前 %s%%）" ;;
+		charge_progress) echo "電池目前 %s%%（目標 %s%%）" ;;
+		charge_completed) echo "電池已充電至 %s%%" ;;
+		charge_abnormal) echo "錯誤：電池充電異常" ;;
+		discharge_invalid_setting) echo "錯誤：%s 不是有效的 battery discharge 設定。請使用 0 到 100 的數字" ;;
+		discharge_lid_open_required) echo "錯誤：放電前必須先打開筆電上蓋" ;;
+		discharge_start) echo "開始放電至 %s%%（目前 %s%%）" ;;
+		discharge_progress) echo "電池目前 %s%%（目標 %s%%）" ;;
+		discharge_completed) echo "電池已放電至 %s%%" ;;
+		discharge_abnormal) echo "錯誤：電池放電異常" ;;
+		maintain_recovering_percentage) echo "恢復電池最佳化設定 %s" ;;
+		maintain_no_setting_to_recover) echo "沒有可恢復的設定，結束" ;;
+		maintain_invalid_setting) echo "錯誤：%s 不是有效的 battery maintain 設定。請使用 0 到 100 的數字" ;;
+		maintain_invalid_setting_with_keywords) echo "錯誤：%s 不是有效的 battery maintain 設定。請使用 0 到 100 的數字，或 'stop' / 'recover' 等動作關鍵字。" ;;
+		maintain_invalid_sailing_target) echo "錯誤：滑行目標 %s 不可大於或等於維持上限 %s" ;;
+		maintain_start) echo "開始電池最佳化：維持 %s%%，滑行至 %s%% %s" ;;
+		maintain_lid_open_required) echo "錯誤：放電前必須先打開筆電上蓋" ;;
+		maintain_trigger_force_discharge) echo "啟用充電限制前，先放電至 %s%%" ;;
+		maintain_force_discharge_done) echo "預先放電完成，繼續進入維持迴圈" ;;
+		maintain_force_discharge_skipped) echo "未要求預先放電，略過" ;;
+		maintain_charging_and_maintaining) echo "開始充電並維持在 %s%%（目前 %s%%）" ;;
+		maintain_recover_wait) echo "5 秒內恢復，請稍候 ." ;;
+		maintain_suspend_wait) echo "5 秒內暫停，請稍候 ." ;;
+		maintain_recovered) echo "電池最佳化已恢復" ;;
+		maintain_recovered_ac_reconnected) echo "電源重新接上，電池最佳化已恢復" ;;
+		maintain_recover_failed) echo "錯誤：電池最佳化恢復失敗" ;;
+		maintain_already_running) echo "電池最佳化已在執行中" ;;
+		maintain_not_running) echo "電池最佳化未在執行" ;;
+		maintain_suspended) echo "電池最佳化已暫停" ;;
+		maintain_suspend_failed) echo "錯誤：電池最佳化暫停失敗" ;;
+		maintain_calibration_process_stopped) echo "🚨 已停止校正程序" ;;
+		maintain_start_discharge_now) echo "開始放電至 %s%%" ;;
+		status_battery_no_charging) echo "電池目前 %s%%, %sV, %s°C, 暫停充電" ;;
+		status_battery_charging) echo "電池目前 %s%%, %sV, %s°C, 充電中" ;;
+		status_battery_discharging) echo "電池目前 %s%%, %sV, %s°C, 放電中" ;;
+		status_health_cycle) echo "電池健康度 %s%%, 循環次數 %s" ;;
+		status_maintain_level_sailing) echo "%s%% 滑行至 %s%%" ;;
+		status_maintain_active) echo "您的電池最佳化維持在 %s" ;;
+		status_maintain_suspended_calibrating) echo "校正進行中，電池最佳化已暫停" ;;
+		status_maintain_suspended) echo "電池最佳化已暫停" ;;
+		status_maintain_not_running) echo "電池最佳化已經停止運作" ;;
+		title_battery) echo "電池" ;;
+		title_battery_optimizer) echo "BatteryOptimizer" ;;
+		title_battery_optimizer_mac) echo "BatteryOptimizer for MAC" ;;
+		title_calibration) echo "電池校正" ;;
+		title_calibration_error) echo "電池校正錯誤" ;;
+		dialog_button_ok) echo "OK" ;;
+		dialog_button_continue) echo "繼續" ;;
+		dialog_button_yes) echo "Yes" ;;
+		dialog_button_no) echo "No" ;;
+		dialog_button_update_now) echo "立即更新" ;;
+		dialog_button_skip_version) echo "跳過此版本" ;;
+		press_any_key_continue) echo "按任意鍵繼續" ;;
+		reinstall_preview) echo "這將執行 curl -sS %s/setup.sh | bash" ;;
+		uninstall_preview) echo "這會恢復充電，並移除 smc 工具與 battery 腳本" ;;
+		visudo_set_owner) echo "設定 visudo 檔案權限給 %s" ;;
+		visudo_already_current) echo "目前的 battery visudo 檔案與版本 %s 所需內容一致" ;;
+		visudo_updated_success) echo "Visudo 檔案更新成功" ;;
+		visudo_validate_error) echo "驗證 visudo 檔案時發生錯誤（理論上不應發生）：" ;;
+		update_specified_file_missing) echo "錯誤：指定的更新檔案不存在" ;;
+		update_dialog_latest) echo "%s 已是最新版，不需要更新" ;;
+		update_dialog_changelog) echo "%s 更新內容如下\n\n%s" ;;
+		update_dialog_confirm) echo "你現在要更新到%s 嗎?" ;;
+		daily_log_table_header) echo "時間 容量 電壓 溫度 健康度 循環次數" ;;
+		ssd_log_table_header) echo "日期 結果 讀取量 寫入量 已用度 電源循環 通電時數 非正常關機 溫度 錯誤" ;;
+		calibrate_log_table_header) echo "時間 已完成 校正前健康度 校正後健康度 耗時/錯誤" ;;
+		notify_battery_monthly_summary) echo "電池目前 %s%%, %sV, %s°C\n健康度 %s%%, 循環次數 %s" ;;
+		notify_calibration_tomorrow) echo "提醒您，明天 (%s) 將進行電池校正" ;;
+		notify_calibration_today) echo "提醒您，今天 (%s) 將進行電池校正" ;;
+		notify_update_available) echo "有新版%s, 請在 Terminal 下輸入 \n\\\"battery update\\\" 更新" ;;
+		aldente_conflict_detected) echo "偵測到 AlDente 正在執行，將其關閉以避免衝突" ;;
+		maintain_stop_charge_above) echo "高於 %s%% 停止充電" ;;
+		maintain_start_charge_below) echo "低於 %s%% 開始充電" ;;
+		maintain_prompt_discharge_now) echo "你要現在就放電到 %s%% 嗎?" ;;
+		schedule_disabled) echo "電池自動校正時程已暫停" ;;
+		schedule_not_set) echo "您尚未設定電池自動校正時程" ;;
+		schedule_disabled_enable_by) echo "您的電池自動校正時程已暫停，要恢復請執行" ;;
+		schedule_next_date) echo "下次校正日期是 %s" ;;
+		schedule_invalid_weekday) echo "錯誤：weekday 必須在 [0..6]" ;;
+		schedule_invalid_month_period) echo "錯誤：month_period 必須在 [1..3]" ;;
+		schedule_invalid_week_period) echo "錯誤：week_period 必須在 [1..12]" ;;
+		schedule_invalid_hour) echo "錯誤：hour 必須在 [0..23]" ;;
+		schedule_invalid_minute) echo "錯誤：minute 必須在 [0..59]" ;;
+		schedule_invalid_day) echo "錯誤：day 必須在 [1..28]" ;;
+		calibrate_skip_run) echo "略過本次校正" ;;
+		calibrate_stop_running) echo "停止執行中的校正程序" ;;
+		calibrate_require_maintain_before) echo "校正前必須先執行 battery maintain" ;;
+		calibrate_error_require_maintain_before_log) echo "校正錯誤：校正前必須先執行 battery maintain" ;;
+		calibrate_wait_open_lid_ac_notify) echo "準備進行電池校正, 您打開筆電上蓋並接上電源後將立刻開始" ;;
+		calibrate_wait_open_lid_ac_log) echo "校正：請打開筆電上蓋並接上電源以開始校正" ;;
+		calibrate_lid_not_open) echo "筆電上蓋沒打開" ;;
+		calibrate_error_lid_not_open_log) echo "校正錯誤：筆電上蓋沒打開" ;;
+		calibrate_no_ac_power) echo "電源沒接" ;;
+		calibrate_error_no_ac_power_log) echo "校正錯誤：未接上電源" ;;
+		calibrate_no_ac_power_logfile) echo "未接上電源" ;;
+		calibrate_start_discharge_15_notify) echo "校正開始! \n開始放電至15%%" ;;
+		calibrate_start_discharge_15_log) echo "校正：校正開始，開始放電至 15%%" ;;
+		calibrate_fail_discharge_15) echo "未成功放電至15%%" ;;
+		calibrate_error_discharge_15_log) echo "校正錯誤：未成功放電至15%%" ;;
+		calibrate_done_discharge_15_charge_100_notify) echo "已放電至15%% \n開始充電到100%%" ;;
+		calibrate_done_discharge_15_charge_100_log) echo "校正：已放電至 15%%，開始充電到 100%%" ;;
+		calibrate_fail_charge_100) echo "未成功充電至100%%" ;;
+		calibrate_error_charge_100_log) echo "校正錯誤：未成功充電至100%%" ;;
+		calibrate_done_charge_100_wait_1h_notify) echo "已充電至100%% \n靜候一小時" ;;
+		calibrate_done_charge_100_wait_1h_log) echo "校正：已充電至 100%%，等待一小時" ;;
+		calibrate_done_wait_1h_log) echo "校正：電池已維持在 100%% 一小時" ;;
+		calibrate_start_discharge_target_log) echo "校正：開始放電至維持電量" ;;
+		calibrate_done_wait_1h_discharge_target_notify) echo "電池已維持在 100%% 一小時 \n開始放電至 %s%%" ;;
+		calibrate_fail_discharge_target) echo "未成功放電至 %s%%" ;;
+		calibrate_error_discharge_target_log) echo "校正錯誤：未成功放電至 %s%%" ;;
+		calibrate_start_charge_100_notify) echo "校正開始！ \n準備充電至 100%%" ;;
+		calibrate_start_charge_100_log) echo "校正：校正開始，開始充電至 100%%" ;;
+		calibrate_done_wait_1h_discharge_15_notify) echo "電池已維持在 100%% 一小時 \n開始放電至 15%%" ;;
+		calibrate_start_discharge_15_phase_log) echo "校正：開始放電至 15%%" ;;
+		calibrate_done_discharge_15_log) echo "校正：已放電至 15%%" ;;
+		calibrate_start_charge_target_log) echo "校正：開始充電至維持電量" ;;
+		calibrate_done_discharge_15_charge_target_notify) echo "已放電至 15%% \n開始充電至 %s%%" ;;
+		calibrate_fail_charge_target) echo "未成功充電至 %s%%" ;;
+		calibrate_error_charge_target_log) echo "校正錯誤：未成功充電至 %s%%" ;;
+		calibrate_health_snapshot_log) echo "電池健康度 %s%%, %sV, %s°C" ;;
+		duration_days_part) echo "%s 天 " ;;
+		duration_hours_part) echo "%s 小時" ;;
+		duration_minutes_part) echo "%s 分" ;;
+		duration_seconds_part) echo "%s 秒" ;;
+		calibrate_completed_notify) echo "校正完成, 共花 %s%s %s\n電池目前 %s%%, %sV, %s°C\n健康度 %s%%, 循環次數 %s" ;;
+		calibrate_completed_log) echo "校正完成, 共花 %s%s %s %s." ;;
+		calibrate_completed_battery_log) echo "電池目前 %s%%, %sV, %s°C" ;;
+		calibrate_completed_health_log) echo "健康度 %s%%, 循環次數 %s" ;;
+		ssd_firmware_not_supported) echo "你的 SMART 韌體目前不支援。" ;;
+		ssd_tool_not_installed) echo "你的 Mac 尚未安裝 SMART 監控工具，可執行 \\\"brew install smartmontools\\\" 安裝。" ;;
+		*) return 1 ;;
+	esac
+}

--- a/i18n/lang_us.sh
+++ b/i18n/lang_us.sh
@@ -1,0 +1,281 @@
+# Battery CLI i18n English catalog
+
+if [[ -n "${BATTERY_I18N_LANG_US_LOADED:-}" ]]; then
+  return 0 2>/dev/null || exit 0
+fi
+BATTERY_I18N_LANG_US_LOADED=1
+
+helpmessage="
+
+Battery CLI utility $BATTERY_CLI_VERSION
+
+Usage:
+
+  battery maintain PERCENTAGE[10-100,stop,suspend,recover] SAILING_TARGET[5-99]
+  - PERCENTAGE is battery level upper bound above which charging is stopped
+  - SAILING_TARGET is battery level lower bound below which charging is started. default value is PERCENTAGE-5 if not specified
+    Examples:
+    battery maintain 80 50    # maintain at 80% with sailing to 50%
+    battery maintain 80    # equivalent to battery maintain 80 75
+    battery maintain stop   # kill running battery maintain process, disable daemon, and enable charging. maintain will not run after reboot
+    battery maintain suspend   # suspend running battery maintain process and enable charging. maintain is automatically resumed after AC adapter is reconnected. used for temporary charging to 100% before travel
+    battery maintain recover   # recover battery maintain process
+
+  battery calibrate 
+    calibrate the battery by discharging it to 15%, then recharging it to 100%, and keeping it there for 1 hour, then discharge to maintained percentage level
+    if macbook lid is not open or AC adapter is not connected, a remind notification will be received.
+    calibration will be started automatically once macbook lid is open and AC adapter is connected
+    notification will be received when each step is completed or error occurs till the end of calibration
+    if you prefer the notifications to stay on until you dismiss it, setup notifications as follows
+        settings > notifications > applications > Script Editor > Choose "Alerts"
+    when external monitor is used, you must setup notifications as follows in order to receive notification successfully
+        system settings > notifications > check 'Allow notifications when mirroring or sharing the display'
+    eg: battery calibrate   # start calibration
+    eg: battery calibrate stop # stop calibration and resume maintain
+	
+  battery schedule
+    schedule periodic calibration at most 4 separate days per month, or specified weekday every 1~12 weeks, or specified one day every 1~3 month. default is one day per month on Day 1 at 9am.
+    Examples:
+    battery schedule    # calibrate on Day 1 at 9am
+    battery schedule day 1 8 15 22    # calibrate on Day 1, 8, 15, 22 at 9am.
+    battery schedule day 3 18 hour 13    # calibrate on Day 3, 18 at 13:00
+    battery schedule day 6 16 26 hour 18 minute 30    # calibrate on Day 6, 16, 26 at 18:30
+    battery schedule weekday 0 week_period 2 hour 21 minute 30 # calibrate on Sunday every 2 weeks at 21:30
+    battery schedule day 5 month_period 3 hour 21 minute 30 # calibrate every 3 month on Day 5 at 21:00
+    battery schedule disable    # disable periodic calibration
+    battery schedule enable    # enable periodic calibration
+    Restrictions:
+        1. at most 4 days per month are allowed
+        2. valid day range [1-28]
+        3. valid hour range [0-23]
+        4. valid minute range [0-59]
+        5. valid weekday range [0-6] 0:Sunday, 1:Monday, ...
+        6. valid week_period range [1-12]
+        7. valid month_period range [1-3]
+
+  battery charge LEVEL[1-100, stop]
+    charge the battery to a certain percentage, and disable charging when that percentage is reached
+    eg: battery charge 90
+    eg: battery charge stop # kill running battery charge process and stop charging
+
+  battery discharge LEVEL[1-100, stop]
+    block power input from the adapter until battery falls to this level
+    eg: battery discharge 90
+    eg: battery discharge stop # kill running battery discharge process and stop discharging
+
+  battery status
+    output battery SMC status, capacity, temperature, health, and cycle count 
+
+  battery dailylog
+    output daily log and show daily log store location
+
+  battery changelog
+    show the changelog of the latest version on Github
+
+  battery calibratelog
+    show calibrate history
+
+  battery logs LINES[integer, optional]
+    output logs of the battery CLI and GUI
+    eg: battery logs 100
+
+  battery language LANG[tw,cn,us,en,zh-TW,zh-CN,zh-Hant,zh-Hans,list]
+    eg: battery language cn     # show status and notification in Simplified Chinese if available
+    eg: battery language zh-CN  # alias of cn
+    eg: battery language tw     # show status and notification in traditional Chinese if available
+    eg: battery language zh-TW  # alias of tw
+    eg: battery language en     # alias of us (English)
+    eg: battery language us     # show status and notification in English
+    eg: battery language list   # list supported language aliases
+
+  battery ssd
+    show SSD disk0 status
+
+  battery ssdlog
+    show SSD disk0 dailylog
+
+  battery update
+    update the battery utility to the latest version
+
+  battery version
+    show current version
+
+  battery reinstall
+    reinstall the battery utility to the latest version (reruns the installation script)
+
+  battery uninstall
+    enable charging, remove the smc tool, and the battery script
+
+"
+
+
+function i18n_help_message_us() {
+	printf "%s\n" "$helpmessage"
+}
+
+function i18n_schedule_display_text_us() {
+	local schedule_txt="$1"
+	schedule_txt=${schedule_txt%" starting"*}
+	printf "%s\n" "$schedule_txt"
+}
+
+function i18n_text_us() {
+	local key="$1"
+	case "$key" in
+		invalid_action) echo "Error: Unknown command '%s'" ;;
+		did_you_mean) echo "Did you mean one of these?" ;;
+		run_battery_help) echo "Run 'battery' without parameters, for list of valid commands." ;;
+		help_current_language) echo "Current language: English (us)" ;;
+		help_i18n_note) echo "Note: CLI help, status, notifications, and major command outputs are localized; a few complex dialogs still use legacy TW/EN branch logic." ;;
+		logs_cli_heading) echo "👾 Battery CLI logs:" ;;
+		logs_gui_heading) echo "🖥️ Battery GUI logs:" ;;
+		logs_config_heading) echo "📁 Config folder details:" ;;
+		logs_data_heading) echo "⚙️ Battery data:" ;;
+		dailylog_heading) echo "Daily log (%s)" ;;
+		ssdlog_heading) echo "SSD daily log (%s)" ;;
+		calibratelog_heading) echo "Calibrate log (%s)" ;;
+		language_list_header) echo "Supported languages (accepted aliases):" ;;
+		language_list_tw) echo "  - tw / zh-TW / zh_TW / zh-Hant -> Traditional Chinese" ;;
+		language_list_cn) echo "  - cn / zh-CN / zh_CN / zh-Hans -> Simplified Chinese" ;;
+		language_list_us) echo "  - us / en / en-US -> English" ;;
+		language_current_tw) echo "Current language setting: Traditional Chinese (tw)" ;;
+		language_current_cn) echo "Current language setting: Simplified Chinese (cn)" ;;
+		language_current_us) echo "Current language setting: English (us)" ;;
+		language_changed_tw) echo "Change language to Traditional Chinese" ;;
+		language_changed_cn) echo "Change language to Simplified Chinese" ;;
+		language_changed_us) echo "Change language to English" ;;
+		language_invalid) echo "Specified language is not recognized. Supported values: [tw, cn, us] (aliases like en, zh-TW, zh-CN are accepted)" ;;
+		charge_invalid_setting) echo "Error: %s is not a valid setting for battery charge. Please use a number between 0 and 100" ;;
+		charge_start) echo "Charging to %s%% from %s%%" ;;
+		charge_progress) echo "Battery at %s%% (target %s%%)" ;;
+		charge_completed) echo "Charging completed at %s%%" ;;
+		charge_abnormal) echo "Error: battery charge abnormal" ;;
+		discharge_invalid_setting) echo "Error: %s is not a valid setting for battery discharge. Please use a number between 0 and 100" ;;
+		discharge_lid_open_required) echo "Error: macbook lid must be open before discharge" ;;
+		discharge_start) echo "Discharging to %s%% from %s%%" ;;
+		discharge_progress) echo "Battery at %s%% (target %s%%)" ;;
+		discharge_completed) echo "Discharging completed at %s%%" ;;
+		discharge_abnormal) echo "Error: battery discharge abnormal" ;;
+		maintain_recovering_percentage) echo "Recovering maintenance percentage %s" ;;
+		maintain_no_setting_to_recover) echo "No setting to recover, exiting" ;;
+		maintain_invalid_setting) echo "Error: %s is not a valid setting for battery maintain. Please use a number between 0 and 100" ;;
+		maintain_invalid_setting_with_keywords) echo "Error: %s is not a valid setting for battery maintain. Please use a number between 0 and 100, or an action keyword like 'stop' or 'recover'." ;;
+		maintain_invalid_sailing_target) echo "Error: sailing target %s larger than or equal to maintain level %s is not allowed" ;;
+		maintain_start) echo "Starting battery maintenance at %s%% with sailing to %s%% %s" ;;
+		maintain_lid_open_required) echo "Error: macbook lid must be open before discharge" ;;
+		maintain_trigger_force_discharge) echo "Triggering discharge to %s before enabling charging limiter" ;;
+		maintain_force_discharge_done) echo "Discharge pre battery maintenance complete, continuing to battery maintenance loop" ;;
+		maintain_force_discharge_skipped) echo "Not triggering discharge as it is not requested" ;;
+		maintain_charging_and_maintaining) echo "Charging to and maintaining at %s%% from %s%%" ;;
+		maintain_recover_wait) echo "Recover in 5 secs, wait ." ;;
+		maintain_suspend_wait) echo "Suspend in 5 secs, wait ." ;;
+		maintain_recovered) echo "Battery maintain is recovered" ;;
+		maintain_recovered_ac_reconnected) echo "Battery maintain is recovered because AC adapter is reconnected" ;;
+		maintain_recover_failed) echo "Error: Battery maintain recover failed" ;;
+		maintain_already_running) echo "Battery maintain is already running" ;;
+		maintain_not_running) echo "Battery maintain is not running" ;;
+		maintain_suspended) echo "Battery maintain is suspended" ;;
+		maintain_suspend_failed) echo "Error: Battery maintain suspend failed" ;;
+		maintain_calibration_process_stopped) echo "🚨 Calibration process have been stopped" ;;
+		maintain_start_discharge_now) echo "Start discharging to %s%%" ;;
+		status_battery_no_charging) echo "Battery at %s%%, %sV, %s°C, no charging" ;;
+		status_battery_charging) echo "Battery at %s%%, %sV, %s°C, charging" ;;
+		status_battery_discharging) echo "Battery at %s%%, %sV, %s°C, discharging" ;;
+		status_health_cycle) echo "Battery health %s%%, Cycle %s" ;;
+		status_maintain_level_sailing) echo "%s%% with sailing to %s%%" ;;
+		status_maintain_active) echo "Your battery is currently being maintained at %s" ;;
+		status_maintain_suspended_calibrating) echo "Calibration ongoing, battery maintain is suspended" ;;
+		status_maintain_suspended) echo "Battery maintain is suspended" ;;
+		status_maintain_not_running) echo "Battery maintain is not running" ;;
+		title_battery) echo "Battery" ;;
+		title_battery_optimizer) echo "BatteryOptimizer" ;;
+		title_battery_optimizer_mac) echo "BatteryOptimizer for MAC" ;;
+		title_calibration) echo "Battery Calibration" ;;
+		title_calibration_error) echo "Battery Calibration Error" ;;
+		dialog_button_ok) echo "OK" ;;
+		dialog_button_continue) echo "Continue" ;;
+		dialog_button_yes) echo "Yes" ;;
+		dialog_button_no) echo "No" ;;
+		dialog_button_update_now) echo "Yes" ;;
+		dialog_button_skip_version) echo "No" ;;
+		press_any_key_continue) echo "Press any key to continue" ;;
+		reinstall_preview) echo "This will run curl -sS %s/setup.sh | bash" ;;
+		uninstall_preview) echo "This will enable charging, and remove the smc tool and battery script" ;;
+		visudo_set_owner) echo "Setting visudo file permissions to %s" ;;
+		visudo_already_current) echo "The existing battery visudo file is what it should be for version %s" ;;
+		visudo_updated_success) echo "Visudo file updated successfully" ;;
+		visudo_validate_error) echo "Error validating visudo file, this should never happen:" ;;
+		update_specified_file_missing) echo "Error: the specified update file is not available" ;;
+		update_dialog_latest) echo "Your version %s is already the latest. No need to update." ;;
+		update_dialog_changelog) echo "%s changes include\n\n%s" ;;
+		update_dialog_confirm) echo "Do you want to update to version %s now?" ;;
+		daily_log_table_header) echo "Time Capacity Voltage Temperature Health Cycle" ;;
+		ssd_log_table_header) echo "Date Result Data_Read Data_Written Used Power_Cycles Power_Hours Unsafe_Shutdowns Temperature Error" ;;
+		calibrate_log_table_header) echo "Time Completed Health_before Health_after Duration/Error" ;;
+		notify_battery_monthly_summary) echo "Battery %s%%, %sV, %s°C\nHealth %s%%, Cycle %s" ;;
+		notify_calibration_tomorrow) echo "Remind you, tomorrow (%s) is battery calibration day." ;;
+		notify_calibration_today) echo "Remind you, today (%s) is battery calibration day." ;;
+		notify_update_available) echo "New version %s available \nUpdate with command \\\"battery update\\\"" ;;
+		aldente_conflict_detected) echo "AlDente is running. Turn it off" ;;
+		maintain_stop_charge_above) echo "Stop charge above %s" ;;
+		maintain_start_charge_below) echo "Charge below %s" ;;
+		maintain_prompt_discharge_now) echo "Do you want to discharge battery to %s%% now?" ;;
+		schedule_disabled) echo "Schedule disabled" ;;
+		schedule_not_set) echo "You haven't scheduled calibration yet" ;;
+		schedule_disabled_enable_by) echo "Your calibration schedule is disabled. Enable it by" ;;
+		schedule_next_date) echo "Next calibration date is %s" ;;
+		schedule_invalid_weekday) echo "Error: weekday must be in [0..6]" ;;
+		schedule_invalid_month_period) echo "Error: month_period must be in [1..3]" ;;
+		schedule_invalid_week_period) echo "Error: week_period must be in [1..12]" ;;
+		schedule_invalid_hour) echo "Error: hour must be in [0..23]" ;;
+		schedule_invalid_minute) echo "Error: minute must be in [0..59]" ;;
+		schedule_invalid_day) echo "Error: day must be in [1..28]" ;;
+		calibrate_skip_run) echo "Skip this calibration" ;;
+		calibrate_stop_running) echo "Killing running calibration daemon" ;;
+		calibrate_require_maintain_before) echo "Battery maintain need to run before calibration" ;;
+		calibrate_error_require_maintain_before_log) echo "Calibration Error: Battery maintain need to run before calibration" ;;
+		calibrate_wait_open_lid_ac_notify) echo "Battery calibration will start immediately after you open macbook lid and connect AC power" ;;
+		calibrate_wait_open_lid_ac_log) echo "Calibration: Please open macbook lid and connect AC to start calibration" ;;
+		calibrate_lid_not_open) echo "Macbook lid is not open!" ;;
+		calibrate_error_lid_not_open_log) echo "Calibration Error: Macbook lid is not open!" ;;
+		calibrate_no_ac_power) echo "No AC power!" ;;
+		calibrate_error_no_ac_power_log) echo "Calibration Error: Macbook has no AC power!" ;;
+		calibrate_no_ac_power_logfile) echo "Macbook has no AC power!" ;;
+		calibrate_start_discharge_15_notify) echo "Calibration has started! \nStart discharging to 15%%" ;;
+		calibrate_start_discharge_15_log) echo "Calibration: Calibration has started! Start discharging to 15%%" ;;
+		calibrate_fail_discharge_15) echo "Discharge to 15%% fail" ;;
+		calibrate_error_discharge_15_log) echo "Calibration Error: Discharge to 15%% fail" ;;
+		calibrate_done_discharge_15_charge_100_notify) echo "Calibration has discharged to 15%% \nStart charging to 100%%" ;;
+		calibrate_done_discharge_15_charge_100_log) echo "Calibration: Calibration has discharged to 15%%. Start charging to 100%%" ;;
+		calibrate_fail_charge_100) echo "Charge to 100%% fail" ;;
+		calibrate_error_charge_100_log) echo "Calibration Error: Charge to 100%% fail" ;;
+		calibrate_done_charge_100_wait_1h_notify) echo "Calibration has charged to 100%% \nWaiting for one hour" ;;
+		calibrate_done_charge_100_wait_1h_log) echo "Calibration: Calibration has charged to 100%%. Waiting for one hour" ;;
+		calibrate_done_wait_1h_log) echo "Calibration: Battery has been maintained at 100%% for one hour" ;;
+		calibrate_start_discharge_target_log) echo "Calibration: Start discharging to maintain percentage" ;;
+		calibrate_done_wait_1h_discharge_target_notify) echo "Battery has been maintained at 100%% for one hour \nStart discharging to %s%%" ;;
+		calibrate_fail_discharge_target) echo "Discharge to %s%% fail" ;;
+		calibrate_error_discharge_target_log) echo "Calibration Error: Discharge to %s%% fail" ;;
+		calibrate_start_charge_100_notify) echo "Calibration has started! \nStart charging to 100%%" ;;
+		calibrate_start_charge_100_log) echo "Calibration: Calibration has started! Start charging to 100%%" ;;
+		calibrate_done_wait_1h_discharge_15_notify) echo "Battery has been maintained at 100%% for one hour \nStart discharging to 15%%" ;;
+		calibrate_start_discharge_15_phase_log) echo "Calibration: Start discharging to 15%%" ;;
+		calibrate_done_discharge_15_log) echo "Calibration: Calibration has discharged to 15%%" ;;
+		calibrate_start_charge_target_log) echo "Calibration: Start charging to maintain percentage" ;;
+		calibrate_done_discharge_15_charge_target_notify) echo "Calibration has discharged to 15%% \nStart charging to %s%%" ;;
+		calibrate_fail_charge_target) echo "Charge to %s%% fail" ;;
+		calibrate_error_charge_target_log) echo "Calibration Error: Charge to %s%% fail" ;;
+		calibrate_health_snapshot_log) echo "Battery health %s%%, %sV, %s°C" ;;
+		duration_days_part) echo "%s day " ;;
+		duration_hours_part) echo "%s hour" ;;
+		duration_minutes_part) echo "%s min" ;;
+		duration_seconds_part) echo "%s sec" ;;
+		calibrate_completed_notify) echo "Calibration completed in %s%s %s.\nBattery %s%%, %sV, %s°C\nHealth %s%%, Cycle %s" ;;
+		calibrate_completed_log) echo "Calibration completed in %s%s %s %s." ;;
+		calibrate_completed_battery_log) echo "Battery %s%%, %sV, %s°C" ;;
+		calibrate_completed_health_log) echo "Health %s%%, Cycle %s" ;;
+		ssd_firmware_not_supported) echo "Your SMART firmware is not supported." ;;
+		ssd_tool_not_installed) echo "SMART monitor tool is not available in your Mac. You may run \\\"brew install smartmontools\\\" to get it." ;;
+		*) return 1 ;;
+	esac
+}

--- a/setup.sh
+++ b/setup.sh
@@ -112,6 +112,11 @@ sudo chown -R $calling_user $configfolder
 
 # Run battery maintain with default percentage 80
 echo "[ 7 ] Set default battery maintain percentage to 80%, can be changed afterwards"
+# Install CLI i18n catalog files for the installed /usr/local/bin/battery script
+mkdir -p "$configfolder/i18n"
+cp -Rf "$batteryfolder/i18n/." "$configfolder/i18n/"
+sudo chown -R "$calling_user" "$configfolder/i18n"
+
 # Setup configuration file
 version=$(echo $(battery version))
 touch $config_file

--- a/update.sh
+++ b/update.sh
@@ -128,6 +128,11 @@ chown $USER $binfolder/battery
 chmod 755 $binfolder/battery
 chmod u+x $binfolder/battery
 
+# Install/update CLI i18n catalog files used by /usr/local/bin/battery
+mkdir -p "$configfolder/i18n"
+cp -Rf "$batteryfolder/i18n/." "$configfolder/i18n/"
+chown -R "$USER" "$configfolder/i18n"
+
 battery_new=$(echo $(cat $binfolder/battery 2>/dev/null))
 battery_version_new=$(echo $(get_parameter "$battery_new" "BATTERY_CLI_VERSION") | tr -d \")
 visudo_version_new=$(echo $(get_parameter "$battery_new" "BATTERY_VISUDO_VERSION") | tr -d \")


### PR DESCRIPTION
## 背景

目前 `battery.sh` 的使用者可見文案分散在腳本各處，存在大量 `if $is_TW` 文案分支，新增語言成本高；
本 PR 主要完成 CLI 國際化重構，並補上簡體中文支援。

## 本次改動

- 將 CLI 國際化從 `battery.sh` 抽離為獨立 `i18n/` 模組目錄
- 新增 i18n loader 相容入口：`i18n/battery_i18n.sh`
- 新增共用 i18n 調度與輔助函式（helper）：`i18n/common.sh`
- 新增語言檔案：
  - `i18n/lang_us.sh`
  - `i18n/lang_tw.sh`
  - `i18n/lang_cn.sh`
- `battery.sh` 啟動時支援從以下路徑載入 i18n：
  - `~/.battery/i18n/battery_i18n.sh`（安裝態）
  - `./i18n/battery_i18n.sh`（倉庫本地執行）
- 將命令入口語言解析前置，使 `help` / 無效命令提示也能依語言顯示
- `battery help` 改為統一走 `show_help()`（依語言渲染）
- 增強 `battery language` 命令：
  - 支援 `cn`
  - 支援 `list`
  - 支援別名（如 `en`、`zh-TW`、`zh-CN`、`zh-Hant`、`zh-Hans`）
- 新增簡體中文完整詞條（`lang_cn.sh` 為獨立詞條檔案）
- 重構 `show_schedule()`：將「英文排程字串 -> 本地化顯示字串」抽到 i18n 專用函式，補上 `cn` 顯示
- `setup.sh` / `update.sh` 改為同步整個 `i18n/` 目錄，避免安裝後缺檔案導致執行失敗
- 修復/整理部分校正日誌耗時格式化變數（無行為變更風險）


## 驗證結果

### 1) 語法檢查（通過）

已通過 `bash -n`：

- `battery.sh`
- `setup.sh`
- `update.sh`
- `i18n/battery_i18n.sh`
- `i18n/common.sh`
- `i18n/lang_us.sh`
- `i18n/lang_tw.sh`
- `i18n/lang_cn.sh`

### 2) i18n 涵蓋檢查（通過）

- `battery.sh` 實際使用到的 i18n key：`137`
- 三個語言檔案對這些 key 的涵蓋缺漏均為 `0`
- `us / tw / cn` 三份語言檔案 key 集合一致（每份 `154` 個 key）

### 3) 執行期冒煙測試（模擬環境，通過）

驗證內容：

- `battery language zh-CN / tw / en`
- `battery help`
- `battery <invalid command>`
- `battery language list`

驗證兩種 loader 情境：

- 本地倉庫 loader（`./i18n/...`）
- 安裝態 loader（`~/.battery/i18n/...`）

結果：`tw / us / cn` 執行時均能正常載入。

### 4) 實機冒煙測試（已安裝本機 battery，通過）

已在本機安裝測試以下命令：

- `battery version`
- `battery help`
- `battery language list`
- `battery status`
- `battery schedule`
- `battery logs 3`
- `battery dailylog`
- `battery calibratelog`
- `battery ssd`
- `battery ssdlog`
- `battery language tw / us / cn`
- `battery definitely_not_a_command`

結果：

- `help` / 錯誤提示 / `status` / `schedule` 在 `tw/us/cn` 下均依語言正確顯示

## 風險評估

- 風險等級：中低
- 風險點主要在 `battery.sh` 文案遷移與 `show_schedule()` 顯示層重構
- 已透過語法檢查、涵蓋檢查、執行期驗證、實機冒煙測試與實機記憶體取樣降低風險

## 建議 Reviewer 關注點

- `show_schedule()` 重構後是否保持原流程行為
- i18n loader 與 `setup.sh` / `update.sh` 的目錄同步邏輯

## 建議回歸（合併前/後）

- `battery help`
- `battery language list`
- `battery language cn`
- `battery language tw`
- `battery language us`
- `battery status`
- `battery schedule`
- `battery changelog`
- `battery logs 10`